### PR TITLE
Ensure targetFilename is not a boolean before writing

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -109,28 +109,21 @@ async function run(args) {
       await writeFile(filename, prettyOutput, "utf8");
       output(`💅 Source updated at ${filename}`);
     }
-    const markdown = targetFilename.endsWith(".md");
-    if (targetFilename && !markdown) {
-      const report = createHtmlDocumentation(ast, {
+
+    if (targetFilename) {
+      const options = {
         title: documentTitle,
         optimizeDiagrams,
         optimizeText,
         textFormatting,
         overviewDiagram,
         diagramWrap,
-      });
-      await writeFile(targetFilename, report, "utf8");
-      output(`📜 Document created at ${targetFilename}`);
-    }
-    if (targetFilename && markdown) {
-      const report = createMarkdownDocumentation(ast, {
-        title: documentTitle,
-        optimizeDiagrams,
-        optimizeText,
-        textFormatting,
-        overviewDiagram,
-        diagramWrap,
-      });
+      };
+
+      const report = targetFilename.endsWith(".md")
+        ? createMarkdownDocumentation(ast, options)
+        : createHtmlDocumentation(ast, options);
+
       await writeFile(targetFilename, report, "utf8");
       output(`📜 Document created at ${targetFilename}`);
     }


### PR DESCRIPTION
# Changes
- Ensures `targetFilename` is set to a non-boolean value before checking if it is a markdown file
- Simplifies creation of the options object(s) for the HTML and Markdown output functions

Fixes #58 